### PR TITLE
Full post condition coverage via burn-and-mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,21 @@ Games that have on-chain economies can leverage their flexibility to express the
 
 ## SFTs and post conditions
 
-Post conditions are tricky because it is impossible to make assertions based on custom `print` events as of Stacks 2.0. Still, native events can be utilised to safeguard SFT actions in different ways. The reference SFT implementation in this repository defines a fungible token using `define-fungible-token` to allow for post conditions asserting the amount of tokens transferred. It enables the user to state "I will transfer exactly 50 semi-fungible tokens of contract A". I am still exploring options in which the user can also assert the type of token. There are definitely ways in which an NFT defined with `define-non-fungible-token` can be used.
+Post conditions are tricky because it is impossible to make assertions based on custom `print` events as of Stacks 2.0. Still, native events can be utilised to safeguard SFT actions. The reference SFT implementation in this repository utilises both `define-fungible-token` and `define-non-fungible-token`. Doing so allows for post conditions asserting both amount of tokens as well as the token ID transferred. Users can thus effectively safeguard their SFTs and express "I will transfer exactly *N* semi-fungible tokens with ID *I* of contract *X*" in post conditions.
 
-Options I am considering:
-- Mint and burn a native NFT with the provided token ID on every SFT action.
-- Define a native NFT with a more complex token identifier and mint these to the contract when an event takes place. The challenge is creating something that is unique whilst still making it easy enough to create assertions for. For example:
-  ```clarity
-  (define-non-fungible-token sft-events {token-id: uint, amount: uint, sender: principal, recipient: principal, nonce: uint})
+The way it works is pretty interesting. First, both a fungible and non-fungible token are defined.
 
-  (define-private (sft-event (token-id uint) (amount uint) (sender principal) (recipient principal))
-  	(nft-mint? sft-events {token-id: token-id, amount: amount, sender: sender, recipient: recipient, nonce: (next-event-nonce)} (as-contract tx-sender))
-  )
-  ```
-The second option makes it so we can also possibly do away with custom `print` events. A downside is that it creates an ever-growing NFT collection on the contract itself.
+```clojure
+(define-fungible-token semi-fungible-token)
+(define-non-fungible-token semi-fungible-token-id {token-id: uint, owner: principal})
+```
+
+Notice how the non-fungible token has a complex asset identifier type definition of `{token-id: uint, owner: principal}`. Although uncommon, it is a perfectly legitimate thing to do. Remember, non-fungible tokens are represented by a unique identifier. The identifier type is something that can be played with. The reason for not simply using a `uint` is because it would make it impossible for multiple principals to a token with the same SFT ID. For SFTs, a token type *T* can have a total supply of *S*, spread out over *N* principals. Using an asset identifier type like the one above allows the contract to hand out multiple NFTs with the "same" token ID. The principal is merely used as a differentiator to make it unique per owner.
+
+With these tokens set up, the contract will do two specific things that can be checked by post conditions when a semi-fungible token is transferred:
+
+1. It transfers the specified amount of `semi-fungible-token` fungible tokens from the sender to the recipient.
+2. It performs a burn-and-mint operation for the `semi-fungible-token-id` NFT for both the sender and the recipient.
+
+Since the fungible token transfer and the burn of the NFT both impact the `tx-sender`, post conditions will be required if the transaction is set to `DENY` mode.
+

--- a/contracts/examples/fractional-sip009-sft.clar
+++ b/contracts/examples/fractional-sip009-sft.clar
@@ -3,6 +3,7 @@
 (define-constant contract-owner tx-sender)
 
 (define-fungible-token fractional-sip009-sft)
+(define-non-fungible-token semi-fungible-token-id {token-id: uint, owner: principal})
 (define-map token-balances {token-id: uint, owner: principal} uint)
 (define-map token-supplies uint uint)
 (define-map token-decimals uint uint)
@@ -60,9 +61,11 @@
 		(
 			(sender-balance (get-balance-uint token-id sender))
 		)
-		(asserts! (is-eq tx-sender sender) err-invalid-sender)
+		(asserts! (or (is-eq sender tx-sender) (is-eq sender contract-caller)) err-invalid-sender)
 		(asserts! (<= amount sender-balance) err-insufficient-balance)
 		(try! (ft-transfer? fractional-sip009-sft amount sender recipient))
+		(try! (tag-nft-token-id {token-id: token-id, owner: sender}))
+		(try! (tag-nft-token-id {token-id: token-id, owner: recipient}))
 		(set-balance token-id (- sender-balance amount) sender)
 		(set-balance token-id (+ (get-balance-uint token-id recipient) amount) recipient)
 		(print {type: "sft_transfer_event", token-id: token-id, amount: amount, sender: sender, recipient: recipient})
@@ -127,6 +130,7 @@
 		)
 		(try! (contract-call? sip009-asset transfer nft-token-id tx-sender (as-contract tx-sender)))
 		(try! (ft-mint? fractional-sip009-sft amount tx-sender))
+		(try! (tag-nft-token-id {token-id: token-id, owner: tx-sender}))
 		(set-balance token-id amount tx-sender)
 		(map-set token-supplies token-id amount)
 		(print {type: "sft_mint_event", token-id: token-id, amount: amount, recipient: tx-sender})
@@ -148,6 +152,16 @@
 		(map-set token-supplies token-id u0)
 		(print {type: "sft_burn_event", token-id: token-id, amount: token-supply, sender: original-sender})
 		(ok token-id)
+	)
+)
+
+(define-private (tag-nft-token-id (nft-token-id {token-id: uint, owner: principal}))
+	(begin
+		(and
+			(is-some (nft-get-owner? semi-fungible-token-id nft-token-id))
+			(try! (nft-burn? semi-fungible-token-id nft-token-id (get owner nft-token-id)))
+		)
+		(nft-mint? semi-fungible-token-id nft-token-id (get owner nft-token-id))
 	)
 )
 

--- a/contracts/semi-fungible-token.clar
+++ b/contracts/semi-fungible-token.clar
@@ -48,11 +48,11 @@
 		(
 			(sender-balance (get-balance-uint token-id sender))
 		)
-		(asserts! (is-eq tx-sender sender) err-invalid-sender)
+		(asserts! (or (is-eq sender tx-sender) (is-eq sender contract-caller)) err-invalid-sender)
 		(asserts! (<= amount sender-balance) err-insufficient-balance)
 		(try! (ft-transfer? semi-fungible-token amount sender recipient))
-		(try! (nft-burn? semi-fungible-token-id {token-id: token-id, owner: tx-sender} tx-sender))
-		(try! (nft-mint? semi-fungible-token-id {token-id: token-id, owner: tx-sender} tx-sender))
+		(try! (tag-nft-token-id {token-id: token-id, owner: sender}))
+		(try! (tag-nft-token-id {token-id: token-id, owner: recipient}))
 		(set-balance token-id (- sender-balance amount) sender)
 		(set-balance token-id (+ (get-balance-uint token-id recipient) amount) recipient)
 		(print {type: "sft_transfer_event", token-id: token-id, amount: amount, sender: sender, recipient: recipient})
@@ -88,13 +88,20 @@
 	(begin
 		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
 		(try! (ft-mint? semi-fungible-token amount recipient))
-		(and
-			(is-none (nft-get-owner? semi-fungible-token-id {token-id: token-id, owner: recipient}))
-			(try! (nft-mint? semi-fungible-token-id {token-id: token-id, owner: recipient} recipient))
-		)
+		(try! (tag-nft-token-id {token-id: token-id, owner: recipient}))
 		(set-balance token-id (+ (get-balance-uint token-id recipient) amount) recipient)
 		(map-set token-supplies token-id (+ (unwrap-panic (get-total-supply token-id)) amount))
 		(print {type: "sft_mint_event", token-id: token-id, amount: amount, recipient: recipient})
 		(ok true)
+	)
+)
+
+(define-private (tag-nft-token-id (nft-token-id {token-id: uint, owner: principal}))
+	(begin
+		(and
+			(is-some (nft-get-owner? semi-fungible-token-id nft-token-id))
+			(try! (nft-burn? semi-fungible-token-id nft-token-id (get owner nft-token-id)))
+		)
+		(nft-mint? semi-fungible-token-id nft-token-id (get owner nft-token-id))
 	)
 )

--- a/sip013-semi-fungible-token-standard.md
+++ b/sip013-semi-fungible-token-standard.md
@@ -10,13 +10,13 @@ Consideration: Technical
 
 Type: Standard
 
-Status: Accepted
+Status: Draft
 
 Created: 12 September 2021
 
 License: CC0-1.0
 
-Sign-off: Jude Nelson <jude@stacks.org>, Technical Steering Committee Chair
+Sign-off: 
 
 Layer: Traits
 
@@ -35,7 +35,7 @@ This SIP's copyright is held by the Stacks Open Internet Foundation.
 
 Digital assets commonly fall in one of two categories; namely, they are either fungible or non-fungible. Fungible tokens are assets like the native Stacks Token (STX), stablecoins, and so on. Non-Fungible Tokens (NFTs) are tokens expressed as digital artwork and other use-cases that demand them to be globally unique. However, not all asset classes can be represented as either exclusively fungible or non-fungible tokens. This is where semi-fungible tokens come in.
 
-Semi-fungible tokens are a combination of the aforementioned digital asset types in that they have both an identifier and an amount. A single semi-fungible token class can therefore represent a multitude of digital assets within a single contract. A user may own 10 tokens of ID 1 and 20 tokens of ID 2, for example. It effectively means that one contract can represent any combination of fungible and non-fungible tokens.
+Semi-fungible tokens are a combination of the aforementioned digital asset types in that they have both an identifier and an amount. A single semi-fungible token class can therefore represent a multitude of digital assets within a single contract. A user may own ten tokens of ID 1 and twenty tokens of ID 2, for example. It effectively means that one contract can represent any combination of fungible and non-fungible tokens.
 
 Some real-world examples can highlight the value and use-cases of semi-fungible tokens. People who collect trading cards or postage stamps will know that not all of them are of equal value, although there may be more than one of a specific kind. Video games can feature in-game items that have different economic values compared to others. There are many more such parallels to be found.
 
@@ -57,7 +57,7 @@ The Semi-Fungible Token trait, `sip013-semi-fungible-token-trait`, has 10 functi
 
 `(get-balance ((token-id uint) (who principal)) (response uint uint))`
 
-Returns the token type balance `token-id` of a specific principal `who` as an unsigned integer wrapped in an `ok` response. It has to respond with `u0` if the principal does not have a balance of the specified token. The function should never return an `err` response and is recommended to be defined as read-only.
+Returns the token type balance `token-id` of a specific principal `who` as an unsigned integer wrapped in an `ok` response. It has to respond with `u0` if the principal does not have a balance of the specified token or if no token with `token-id` exists. The function should never return an `err` response and is recommended to be defined as read-only.
 
 ### Overall balance
 
@@ -87,16 +87,16 @@ Returns the decimal places of a token type. This is purely for display reasons, 
 
 `(get-token-uri ((token-id uint)) (response (optional (string-ascii 256)) uint))`
 
-Returns an optional ASCII string that is a valid URI which resolves to this token type's metadata. These files can provide off-chain metadata about that particular token type, like descriptions, imagery, or any other information. The exact structure of the metadata is out of scope for this SIP. However, the metadata file should be in JSON format and should include a `version` property containing a string:
+Returns an optional ASCII string that is a valid URI which resolves to this token type's metadata. These files can provide off-chain metadata about that particular token type, like descriptions, imagery, or any other information. The exact structure of the metadata is out of scope for this SIP. However, the metadata file should be in JSON format and should include a `sip` property containing a number:
 
 ```JSON
 {
-	"version": "1"
+	"sip": 16
 	// ... any other properties
 }
 ```
 
-Applications consuming these metadata files can base display capabilities on the version string.
+Applications consuming these metadata files can base display capabilities on the `sip` value. It should refer to a SIP number describing a JSON metadata standard.
 
 ### Transfer
 
@@ -111,15 +111,21 @@ Transfer a token from the sender to the recipient. It is recommended to leverage
 | `u3`       | Amount is `u0`.                                  |
 | `u4`       | The sender is not authorised to transfer tokens. |
 
-Error code `u4` is broad and may be returned under different cirumstances. For example, a token  contract with an allowance mechanism can return `(err u4)` when the `sender` parameter has no allowance for the specified token amount or if the sender is not equal to `tx-sender`. A token contract without an allowance mechanism can return `(err u4)` simply when the `sender` is not equal to the `tx-sender`.
+Error code `u4` is broad and may be returned under different cirumstances. For example, a token  contract with an allowance mechanism can return `(err u4)` when the `sender` parameter has no allowance for the specified token amount or if the sender is not equal to `tx-sender` or `contract-owner`. A token contract without an allowance mechanism can return `(err u4)` simply when the `sender` is not what is expected.
 
-This function should emit a special transfer event, as detailed in the Events section of this document.
+Since it is possible for smart contracts to own tokens, it is recommended to check for both `tx-sender` and `contract-caller` as it allows smart contracts to transfer tokens it owns without having to resort to using `as-contract`. Such a guard can be constructed as follows:
+
+```clarity
+(asserts! (or (is-eq sender tx-sender) (is-eq sender contract-caller)) (err u4))
+```
+
+The `transfer` function should emit a special transfer event, as detailed in the Events section of this document.
 
 ### Transfer with memo
 
 `(transfer-memo ((token-id uint) (amount uint) (sender principal) (recipient principal) (memo (buff 34))) (response bool uint))`
 
-Transfer a token from the sender to the recipient and emit a memo. This function follows the exact same procedure as `transfer` but emits the provided memo via `(print memo)`. The memo event should be the final event emitted by the contract. (See also the #vents section of this document below.)
+Transfer a token from the sender to the recipient and emit a memo. This function follows the exact same procedure as `transfer` but emits the provided memo via `(print memo)`. The memo event should be the final event emitted by the contract. (See also the events section of this document below.)
 
 ### Bulk transfers
 
@@ -195,18 +201,26 @@ The recommended native asset primitives to use:
 - `ft-get-supply`
 - `ft-mint?`
 - `ft-transfer?`
+- And their NFT equivalents.
 
 ## Implementing in wallets and other applications
 
 Applications that interact with semi-fungible token contracts should validate if those contracts implement the SFT trait. If they do, then the application can use the interface described in this SIP for making transfers and getting other token information.
 
-All of the functions in this trait return the `response` type, which is a requirement of trait definitions in Clarity. However, some of these functions should be "fail-proof", in the sense that they should never return an error. These "fail-proof" functions are those that have been recommended as read-only. If a contract that implements this trait returns an error for these functions, it may be an indication of a faulty contract, and consumers of those contracts should proceed with caution.
+All of the functions in this trait return the `response` type, which is a requirement of trait definitions in Clarity. However, some of these functions should be "fail-proof", in the sense that they should never return an error. The "fail-proof" functions are those that have been recommended as read-only. If a contract that implements this trait returns an error for these functions, it may be an indication of a faulty contract, and consumers of those contracts should proceed with caution.
 
 ## Use of post conditions
 
 The Stacks blockchain includes a feature known as Post Conditions. By defining post conditions, users can create transactions that include pre-defined guarantees about what might happen in a contract. These post conditions can also be used to provide guarantees for custom fungible and non-fungible tokens that were defined using built-in Clarity primitives.
 
-However, since there are no Clarity primitive counterparts for semi-fungible tokens, post conditions can only safeguard users on a basic level. Semi-fungible token contracts that are implemented using the Clarity primitive `define-fungible-token` give users the ability to make assertions against the total number of tokens transferred in any single call. It does not, however, provide any securities as to the type of token transferred.
+There are no Clarity primitive counterparts for semi-fungible tokens, but contract developers can leverage a combination of post conditions to achieve the same result.
+
+There are two factor that should be checked by post conditions:
+
+1. The amount of semi-fungible tokens being transferred.
+2. The token ID of the semi-fungible token being transferred.
+
+To that end, it is recommended that developers use both Clarity primitives in their design. Semi-fungible token contracts can achieve complete post condition coverage by using both `define-fungible-token` and `define-non-fungible-token`.
 
 For strategies on how to best guard a semi-fungible token contract with post conditions, see the reference implementation at the end of this document.
 


### PR DESCRIPTION
Implements NFT burn-and-mint for the reference and example contracts so that both the amount as well as the token ID are covered by post conditions.

Includes updated README and SIP document.